### PR TITLE
tests for sqlite, mysql and postgres

### DIFF
--- a/lib/Catmandu/Store/DBI.pm
+++ b/lib/Catmandu/Store/DBI.pm
@@ -33,7 +33,7 @@ has _dbh => (
 );
 
 sub handler_namespace {
-   'Catmandu::Store::DBI::Handler'; 
+   'Catmandu::Store::DBI::Handler';
 }
 
 sub _build_handler {

--- a/lib/Catmandu/Store/DBI/Handler/MySQL.pm
+++ b/lib/Catmandu/Store/DBI/Handler/MySQL.pm
@@ -8,9 +8,10 @@ with 'Catmandu::Store::DBI::Handler';
 
 # text types are case-insensitive in MySQL
 sub _column_sql {
-    my ($self, $map) = @_;
+    my ($self, $map,$bag) = @_;
     my $col = $map->{column};
-    my $sql = "$col ";
+    my $dbh = $bag->store->dbh;
+    my $sql = $dbh->quote_identifier($col)." ";
     if ($map->{type} eq 'string' && $map->{unique}) {
         $sql .= 'VARCHAR(255) BINARY';
     } elsif ($map->{type} eq 'string') {
@@ -39,24 +40,25 @@ sub _column_sql {
 sub create_table {
     my ($self, $bag) = @_;
     my $mapping = $bag->mapping;
-    my $name = $bag->name;
     my $dbh = $bag->store->dbh;
-    my $sql = "CREATE TABLE IF NOT EXISTS $name(".
-        join(',', map { $self->_column_sql($_) } values %$mapping).")";
+    my $q_name = $dbh->quote_identifier($bag->name);
+    my $sql = "CREATE TABLE IF NOT EXISTS $q_name(".
+        join(',', map { $self->_column_sql($_,$bag) } values %$mapping).")";
     $dbh->do($sql)
         or Catmandu::Error->throw($dbh->errstr);
 }
 
 sub add_row {
     my ($self, $bag, $row) = @_;
-    my @cols = keys %$row;
-    my @vals = values %$row;
-    my $name = $bag->name;
-    my $sql = "INSERT INTO $name(".join(',', @cols).") VALUES(".
-        join(',', ('?') x @cols).") ON DUPLICATE KEY UPDATE ".
-        join(',', map { "$_=VALUES($_)" } @cols);
-
     my $dbh = $bag->store->dbh;
+    my @cols = keys %$row;
+    my @q_cols = map { $dbh->quote_identifier($_) } @cols;
+    my @vals = values %$row;
+    my $q_name = $dbh->quote_identifier($bag->name);
+    my $sql = "INSERT INTO $q_name(".join(',', @q_cols).") VALUES(".
+        join(',', ('?') x @q_cols).") ON DUPLICATE KEY UPDATE ".
+        join(',', map { "$_=VALUES($_)" } @q_cols);
+
     my $sth = $dbh->prepare_cached($sql)
         or Catmandu::Error->throw($dbh->errstr);
     $sth->execute(@vals) or Catmandu::Error->throw($sth->errstr);

--- a/lib/Catmandu/Store/DBI/Handler/SQLite.pm
+++ b/lib/Catmandu/Store/DBI/Handler/SQLite.pm
@@ -7,9 +7,10 @@ use namespace::clean;
 with 'Catmandu::Store::DBI::Handler';
 
 sub _column_sql {
-    my ($self, $map) = @_;
+    my ($self, $map,$bag) = @_;
     my $col = $map->{column};
-    my $sql = "$col ";
+    my $dbh = $bag->store->dbh;
+    my $sql = $dbh->quote_identifier($col)." ";
     if ($map->{type} eq 'string') {
         $sql .= 'TEXT';
     } elsif ($map->{type} eq 'integer') {
@@ -29,11 +30,12 @@ sub _column_sql {
 sub create_table {
     my ($self, $bag) = @_;
     my $mapping = $bag->mapping;
-    my $name = $bag->name;
     my $dbh = $bag->store->dbh;
-    
-    my $sql = "CREATE TABLE IF NOT EXISTS $name(".
-        join(',', map { $self->_column_sql($_) } values %$mapping).")";
+    my $name = $bag->name;
+    my $q_name = $dbh->quote_identifier($name);
+
+    my $sql = "CREATE TABLE IF NOT EXISTS $q_name(".
+        join(',', map { $self->_column_sql($_,$bag) } values %$mapping).")";
 
     $dbh->do($sql)
         or Catmandu::Error->throw($dbh->errstr);
@@ -41,7 +43,9 @@ sub create_table {
     for my $map (values %$mapping) {
         next if $map->{unique} || !$map->{index};
         my $col = $map->{column};
-        my $idx_sql = "CREATE INDEX IF NOT EXISTS ${name}_${col}_idx ON $name($col)";
+        my $q_col = $dbh->quote_identifier($col);
+        my $q_idx = $dbh->quote_identifier("${name}_${col}_idx");
+        my $idx_sql = "CREATE INDEX IF NOT EXISTS ${q_idx} ON $q_name($q_col)";
         $dbh->do($idx_sql)
             or Catmandu::Error->throw($dbh->errstr);
     }
@@ -49,13 +53,14 @@ sub create_table {
 
 sub add_row {
     my ($self, $bag, $row) = @_;
-    my @cols = keys %$row;
-    my @values = values %$row;
-    my $name = $bag->name;
-    my $sql = "INSERT OR REPLACE INTO $name(".
-        join(',', @cols).") VALUES(".join(',', ('?') x @cols).")";
-
     my $dbh = $bag->store->dbh;
+    my @cols = keys %$row;
+    my @q_cols = map { $dbh->quote_identifier($_) } @cols;
+    my @values = values %$row;
+    my $q_name = $dbh->quote_identifier($bag->name);
+    my $sql = "INSERT OR REPLACE INTO $q_name(".
+        join(',', @q_cols).") VALUES(".join(',', ('?') x @cols).")";
+
     my $sth = $dbh->prepare_cached($sql)
         or Catmandu::Error->throw($dbh->errstr);
     $sth->execute(@values) or Catmandu::Error->throw($sth->errstr);

--- a/t/06-sqlite.t
+++ b/t/06-sqlite.t
@@ -1,0 +1,151 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+require Catmandu::Store::DBI;
+require Catmandu::Serializer::json;
+
+my $driver_found = 1;
+{
+    local $@;
+    eval {
+        require DBD::SQLite;
+    };
+    if($@){
+        $driver_found = 0;
+    }
+}
+
+
+if(!$driver_found){
+
+    plan skip_all => "database driver DBD::SQLite not found";
+
+}else{
+    sub get {
+        my($dbh,$table,$id_field,$id)=@_;
+        my $sql = "SELECT * FROM ".$dbh->quote_identifier($table)." WHERE ".$dbh->quote_identifier($id_field)."=?";
+        my $sth = $dbh->prepare_cached($sql) or die($dbh->errstr);
+        $sth->execute($id) or die($sth->errstr);
+        $sth->fetchrow_hashref;
+    }
+
+    my $record = {
+        _id => "mylittlepony",
+        title => "My little pony",
+        author => "unknown"
+    };
+    my $serializer = Catmandu::Serializer::json->new();
+
+    #impliciet mapping (old behaviour) => except for the _id that is not stored anymore in 'data'
+    {
+        my $bag;
+        lives_ok(sub { $bag = Catmandu::Store::DBI->new( data_source => "dbi:SQLite:dbname=:memory:" )->bag(); },"no mapping - bag created");
+
+        lives_ok(sub{ $bag->add($record); },"no mapping - add record");
+
+        my $row = get( $bag->store->dbh , "data" , "id" , $record->{_id} );
+        $row->{data} = $serializer->deserialize($row->{data});
+
+        my $expected = +{ id => $record->{_id}, data => { %$record } };
+        delete $expected->{data}->{_id};
+
+        is_deeply( $row, $expected , "expected fields created" );
+    }
+
+    #explicit mapping (no double field _id anymore)
+    {
+        my $bag;
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                data_source => "dbi:SQLite:dbname=:memory:",
+                bags => {
+                    data => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag();
+        },"mapping given - bag created");
+
+        lives_ok(sub{ $bag->add($record); },"mapping given - add record");
+
+        my $row = get( $bag->store->dbh , "data" , "_id" , $record->{_id} );
+        is_deeply $row,$record,"mapping given - expected fields created";
+
+        lives_ok(sub { $bag->count },"mapping given - count successfull");
+    }
+    {
+        my $bag;
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                data_source => "dbi:SQLite:dbname=:memory:",
+                bags => {
+                    data => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag();
+        },"iterator - bag created");
+        my @d_records = map { +{ author => "Dostoyevsky" } } 1..10;
+        my @t_records = map { +{ author => "Tolstoj" } } 1..15;
+
+        $bag->add_many([@d_records,@t_records],"iterator - added many records");
+
+        #iterator select
+        my $iterator;
+
+        lives_ok(sub{ $iterator = $bag->select(author => "Tolstoj"); },"iterator - select(key => value) created");
+        cmp_ok($iterator->count,"==",scalar(@t_records),"iterator - select(key => value) contains correct number of records");
+
+        #iterator slice(start)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5); },"iterator - select(key => value)->slice(start) created");
+        cmp_ok($iterator->count,"==",5,"iterator - select(key => value)->slice(start) contains correct number of records");
+
+        #iterator slice(start,limit)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5,1); },"iterator - select(key => value)->slice(start,limit) created");
+        cmp_ok($iterator->count,"==",1,"iterator - select(key => value)->slice(start,limit) contains correct number of records");
+
+        #first
+        my $r;
+        lives_ok(sub{ $r = $bag->select(author => "Dostoyevsky")->first; },"iterator - select(key => value)->first created");
+        isnt($r,undef,"iterator - select(key => value)->first contains one record");
+
+    }
+
+    done_testing 16;
+
+}

--- a/t/07-mysql.t
+++ b/t/07-mysql.t
@@ -1,0 +1,168 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+require Catmandu::Store::DBI;
+require Catmandu::Serializer::json;
+
+my $driver_found = 1;
+{
+    local $@;
+    eval {
+        require DBD::mysql;
+    };
+    if($@){
+        $driver_found = 0;
+    }
+}
+my %store_args = (
+    data_source => $ENV{CATMANDU_DBI_TEST_MYSQL_DSN},
+    username => $ENV{CATMANDU_DBI_TEST_MYSQL_USERNAME},
+    password => $ENV{CATMANDU_DBI_TEST_MYSQL_PASSWORD}
+);
+
+if(!$driver_found){
+
+    plan skip_all => "database driver DBD::mysql not found";
+
+}
+elsif(!(
+    $ENV{CATMANDU_DBI_TEST_MYSQL_DSN} || $ENV{CATMANDU_DBI_TEST_MYSQL_USERNAME} || $ENV{CATMANDU_DBI_TEST_MYSQL_PASSWORD}
+)){
+
+    plan skip_all => "not all mysql connection details are set";
+
+}else{
+    sub get {
+        my($dbh,$table,$id_field,$id)=@_;
+        my $sql = "SELECT * FROM ".$dbh->quote_identifier($table)." WHERE ".$dbh->quote_identifier($id_field)."=?";
+        my $sth = $dbh->prepare_cached($sql) or die($dbh->errstr);
+        $sth->execute($id) or die($sth->errstr);
+        $sth->fetchrow_hashref;
+    }
+
+    my $record = {
+        _id => "mylittlepony",
+        title => "My little pony",
+        author => "unknown"
+    };
+    my $serializer = Catmandu::Serializer::json->new();
+
+    #impliciet mapping (old behaviour)
+    {
+        my $bag;
+        my $bag_name = "data1";
+        lives_ok(sub { $bag = Catmandu::Store::DBI->new( %store_args )->bag($bag_name); },"no mapping - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"no mapping - bag $bag_name cleared");
+
+        lives_ok(sub{ $bag->add($record); },"no mapping - add record");
+
+        my $row = get( $bag->store->dbh , $bag_name , "id" , $record->{_id} );
+        $row->{data} = $serializer->deserialize($row->{data});
+
+        my $expected = +{ id => $record->{_id}, data => { %$record } };
+        delete $expected->{data}->{_id};
+
+        is_deeply( $row, $expected , "no mapping - expected fields created" );
+    }
+
+    #explicit mapping
+    {
+        my $bag;
+        my $bag_name = "data2";
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                %store_args,
+                bags => {
+                    $bag_name => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag($bag_name);
+        },"mapping given - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"mapping given - bag $bag_name cleared");
+
+        lives_ok(sub{ $bag->add($record); },"mapping given - record added to bag $bag_name");
+
+        my $row = get( $bag->store->dbh , $bag_name , "_id" , $record->{_id} );
+        is_deeply $row,$record,"mapping given - expected fields created";
+
+        lives_ok(sub { $bag->count },"mapping given - count ok");
+    }
+    {
+        my $bag;
+        my $bag_name = "data3";
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                %store_args,
+                bags => {
+                    $bag_name => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag($bag_name);
+        },"iterator - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"iterator - bag $bag_name cleared");
+
+        my @d_records = map { +{ author => "Dostoyevsky" } } 1..10;
+        my @t_records = map { +{ author => "Tolstoj" } } 1..15;
+
+        $bag->add_many([@d_records,@t_records]);
+
+        #iterator select
+        my $iterator;
+
+        lives_ok(sub{ $iterator = $bag->select(author => "Tolstoj"); },"iterator - select(key => value) created");
+        cmp_ok($iterator->count,"==",scalar(@t_records),"iterator - count contains correct number of records");
+
+        #iterator slice(start)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5); },"iterator - slice(start) created");
+        cmp_ok($iterator->count,"==",5,"slice(start)->count contains correct number of records");
+
+        #iterator slice(start,limit)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5,1); },"iterator - slice(start,limit) created");
+        cmp_ok($iterator->count,"==",1,"slice(start,limit)->count contains correct number of records");
+
+        #first
+        my $r;
+        lives_ok(sub{ $r = $bag->select(author => "Dostoyevsky")->first; },"iterator - select(key => value)->first created");
+        isnt($r,undef,"iterator - select(key => value)->first contains one record");
+
+    }
+
+    done_testing 19;
+}

--- a/t/08-postgres.t
+++ b/t/08-postgres.t
@@ -1,0 +1,168 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+require Catmandu::Store::DBI;
+require Catmandu::Serializer::json;
+
+my $driver_found = 1;
+{
+    local $@;
+    eval {
+        require DBD::Pg;
+    };
+    if($@){
+        $driver_found = 0;
+    }
+}
+my %store_args = (
+    data_source => $ENV{CATMANDU_DBI_TEST_PG_DSN},
+    username => $ENV{CATMANDU_DBI_TEST_PG_USERNAME},
+    password => $ENV{CATMANDU_DBI_TEST_PG_PASSWORD}
+);
+
+if(!$driver_found){
+
+    plan skip_all => "database driver DBD::Pg not found";
+
+}
+elsif(!(
+    $ENV{CATMANDU_DBI_TEST_PG_DSN} || $ENV{CATMANDU_DBI_TEST_PG_USERNAME} || $ENV{CATMANDU_DBI_TEST_PG_PASSWORD}
+)){
+
+    plan skip_all => "not all postgres connection details are set";
+
+}else{
+    sub get {
+        my($dbh,$table,$id_field,$id)=@_;
+        my $sql = "SELECT * FROM ".$dbh->quote_identifier($table)." WHERE ".$dbh->quote_identifier($id_field)."=?";
+        my $sth = $dbh->prepare_cached($sql) or die($dbh->errstr);
+        $sth->execute($id) or die($sth->errstr);
+        $sth->fetchrow_hashref;
+    }
+
+    my $record = {
+        _id => "mylittlepony",
+        title => "My little pony",
+        author => "unknown"
+    };
+    my $serializer = Catmandu::Serializer::json->new();
+
+    #impliciet mapping (old behaviour)
+    {
+        my $bag;
+        my $bag_name = "data1";
+        lives_ok(sub { $bag = Catmandu::Store::DBI->new( %store_args )->bag($bag_name); },"no mapping - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"no mapping - bag $bag_name cleared");
+
+        lives_ok(sub{ $bag->add($record); },"no mapping - add record");
+
+        my $row = get( $bag->store->dbh , $bag_name , "id" , $record->{_id} );
+        $row->{data} = $serializer->deserialize($row->{data});
+
+        my $expected = +{ id => $record->{_id}, data => { %$record } };
+        delete $expected->{data}->{_id};
+
+        is_deeply( $row, $expected , "no mapping - expected fields created" );
+    }
+
+    #explicit mapping
+    {
+        my $bag;
+        my $bag_name = "data2";
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                %store_args,
+                bags => {
+                    $bag_name => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag($bag_name);
+        },"mapping given - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"mapping given - bag $bag_name cleared");
+
+        lives_ok(sub{ $bag->add($record); },"mapping given - record added to bag $bag_name");
+
+        my $row = get( $bag->store->dbh , $bag_name , "_id" , $record->{_id} );
+        is_deeply $row,$record,"mapping given - expected fields created";
+
+        lives_ok(sub { $bag->count },"mapping given - count ok");
+    }
+    {
+        my $bag;
+        my $bag_name = "data3";
+        lives_ok(sub {
+            $bag = Catmandu::Store::DBI->new(
+                %store_args,
+                bags => {
+                    $bag_name => {
+                        mapping => {
+                            _id => {
+                                column => "_id",
+                                type => "string",
+                                index => 1,
+                                required => 1,
+                                unique => 1
+                            },
+                            title => {
+                                column => "title",
+                                type => "string"
+                            },
+                            author => {
+                                column => "author",
+                                type => "string"
+                            }
+                        }
+                    }
+                }
+            )->bag($bag_name);
+        },"iterator - bag $bag_name created");
+        lives_ok(sub { $bag->delete_all; },"iterator - bag $bag_name cleared");
+
+        my @d_records = map { +{ author => "Dostoyevsky" } } 1..10;
+        my @t_records = map { +{ author => "Tolstoj" } } 1..15;
+
+        $bag->add_many([@d_records,@t_records]);
+
+        #iterator select
+        my $iterator;
+
+        lives_ok(sub{ $iterator = $bag->select(author => "Tolstoj"); },"iterator - select(key => value) created");
+        cmp_ok($iterator->count,"==",scalar(@t_records),"iterator - count contains correct number of records");
+
+        #iterator slice(start)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5); },"iterator - slice(start) created");
+        cmp_ok($iterator->count,"==",5,"slice(start)->count contains correct number of records");
+
+        #iterator slice(start,limit)
+        lives_ok(sub{ $iterator = $bag->select(author => "Dostoyevsky")->slice(5,1); },"iterator - slice(start,limit) created");
+        cmp_ok($iterator->count,"==",1,"slice(start,limit)->count contains correct number of records");
+
+        #first
+        my $r;
+        lives_ok(sub{ $r = $bag->select(author => "Dostoyevsky")->first; },"iterator - select(key => value)->first created");
+        isnt($r,undef,"iterator - select(key => value)->first contains one record");
+
+    }
+
+    done_testing 19;
+}


### PR DESCRIPTION
1. tests for sqlite, mysql and postgres
2. all fields are quoted
3. field data no longer forced in tables
4. slice(start) works now by using a default max limit (2**63 - 1). 
    This should be big enough for most use cases.