### PR TITLE
Adding support for configurable order of result in generators #25

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2017 by Nicolas Steenlant.
+This software is copyright (c) 2018 by Patrick Hochstenbach.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2017 by Nicolas Steenlant.
+This software is Copyright (c) 2018 by Patrick Hochstenbach.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2017 by Nicolas Steenlant.
+This software is Copyright (c) 2018 by Patrick Hochstenbach.
 
 This is free software, licensed under:
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -117,218 +117,222 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Catmandu-1.0606
-    pathname: N/NI/NICS/Catmandu-1.0606.tar.gz
+  Catmandu-1.08
+    pathname: N/NI/NICS/Catmandu-1.08.tar.gz
     provides:
-      Catmandu 1.0606
-      Catmandu::Addable 1.0606
-      Catmandu::ArrayIterator 1.0606
-      Catmandu::BadArg 1.0606
-      Catmandu::BadFixArg 1.0606
-      Catmandu::BadVal 1.0606
-      Catmandu::Bag 1.0606
-      Catmandu::Bag::IdGenerator 1.0606
-      Catmandu::Bag::IdGenerator::Mock 1.0606
-      Catmandu::Bag::IdGenerator::UUID 1.0606
-      Catmandu::Buffer 1.0606
-      Catmandu::CLI 1.0606
-      Catmandu::CQLSearchable 1.0606
-      Catmandu::Cmd 1.0606
-      Catmandu::Cmd::compile 1.0606
-      Catmandu::Cmd::config 1.0606
-      Catmandu::Cmd::convert 1.0606
-      Catmandu::Cmd::copy 1.0606
-      Catmandu::Cmd::count 1.0606
-      Catmandu::Cmd::delete 1.0606
-      Catmandu::Cmd::drop 1.0606
-      Catmandu::Cmd::export 1.0606
-      Catmandu::Cmd::help 1.0606
-      Catmandu::Cmd::import 1.0606
-      Catmandu::Cmd::info 1.0606
-      Catmandu::Cmd::run 1.0606
+      Catmandu 1.08
+      Catmandu::Addable 1.08
+      Catmandu::ArrayIterator 1.08
+      Catmandu::BadArg 1.08
+      Catmandu::BadFixArg 1.08
+      Catmandu::BadVal 1.08
+      Catmandu::Bag 1.08
+      Catmandu::Bag::IdGenerator 1.08
+      Catmandu::Bag::IdGenerator::Mock 1.08
+      Catmandu::Bag::IdGenerator::UUID 1.08
+      Catmandu::Buffer 1.08
+      Catmandu::CLI 1.08
+      Catmandu::CQLSearchable 1.08
+      Catmandu::Cmd 1.08
+      Catmandu::Cmd::compile 1.08
+      Catmandu::Cmd::config 1.08
+      Catmandu::Cmd::convert 1.08
+      Catmandu::Cmd::copy 1.08
+      Catmandu::Cmd::count 1.08
+      Catmandu::Cmd::delete 1.08
+      Catmandu::Cmd::drop 1.08
+      Catmandu::Cmd::export 1.08
+      Catmandu::Cmd::help 1.08
+      Catmandu::Cmd::import 1.08
+      Catmandu::Cmd::info 1.08
+      Catmandu::Cmd::run 1.08
       Catmandu::Cmd::stream 1.0505
-      Catmandu::Cmd::touch 1.0606
-      Catmandu::Counter 1.0606
-      Catmandu::Droppable 1.0606
-      Catmandu::Env 1.0606
-      Catmandu::Error 1.0606
-      Catmandu::Expander 1.0606
-      Catmandu::Exporter 1.0606
-      Catmandu::Exporter::CSV 1.0606
-      Catmandu::Exporter::Count 1.0606
-      Catmandu::Exporter::JSON 1.0606
-      Catmandu::Exporter::Mock 1.0606
-      Catmandu::Exporter::Multi 1.0606
-      Catmandu::Exporter::Null 1.0606
-      Catmandu::Exporter::TSV 1.0606
-      Catmandu::Exporter::Text 1.0606
-      Catmandu::Exporter::YAML 1.0606
-      Catmandu::FileBag 1.0606
-      Catmandu::FileBag::Index 1.0606
-      Catmandu::FileStore 1.0606
+      Catmandu::Cmd::touch 1.08
+      Catmandu::Counter 1.08
+      Catmandu::Droppable 1.08
+      Catmandu::Env 1.08
+      Catmandu::Error 1.08
+      Catmandu::Error::Source 1.08
+      Catmandu::Expander 1.08
+      Catmandu::Exporter 1.08
+      Catmandu::Exporter::CSV 1.08
+      Catmandu::Exporter::Count 1.08
+      Catmandu::Exporter::JSON 1.08
+      Catmandu::Exporter::Mock 1.08
+      Catmandu::Exporter::Multi 1.08
+      Catmandu::Exporter::Null 1.08
+      Catmandu::Exporter::TSV 1.08
+      Catmandu::Exporter::Text 1.08
+      Catmandu::Exporter::YAML 1.08
+      Catmandu::FileBag 1.08
+      Catmandu::FileBag::Index 1.08
+      Catmandu::FileStore 1.08
       Catmandu::Fix 1.0201
-      Catmandu::Fix::Base 1.0606
-      Catmandu::Fix::Bind 1.0606
-      Catmandu::Fix::Bind::Group 1.0606
-      Catmandu::Fix::Bind::benchmark 1.0606
-      Catmandu::Fix::Bind::hashmap 1.0606
-      Catmandu::Fix::Bind::identity 1.0606
-      Catmandu::Fix::Bind::importer 1.0606
-      Catmandu::Fix::Bind::iterate 1.0606
-      Catmandu::Fix::Bind::list 1.0606
-      Catmandu::Fix::Bind::maybe 1.0606
-      Catmandu::Fix::Bind::timeout 1.0606
-      Catmandu::Fix::Bind::visitor 1.0606
-      Catmandu::Fix::Bind::with 1.0606
-      Catmandu::Fix::Condition 1.0606
-      Catmandu::Fix::Condition::SimpleAllTest 1.0606
-      Catmandu::Fix::Condition::SimpleAnyTest 1.0606
-      Catmandu::Fix::Condition::SimpleCompareTest 1.0606
-      Catmandu::Fix::Condition::all_equal 1.0606
-      Catmandu::Fix::Condition::all_match 1.0606
-      Catmandu::Fix::Condition::any_equal 1.0606
-      Catmandu::Fix::Condition::any_match 1.0606
-      Catmandu::Fix::Condition::exists 1.0606
-      Catmandu::Fix::Condition::greater_than 1.0606
-      Catmandu::Fix::Condition::in 1.0606
-      Catmandu::Fix::Condition::is_array 1.0606
-      Catmandu::Fix::Condition::is_false 1.0606
-      Catmandu::Fix::Condition::is_null 1.0606
-      Catmandu::Fix::Condition::is_number 1.0606
-      Catmandu::Fix::Condition::is_object 1.0606
-      Catmandu::Fix::Condition::is_string 1.0606
-      Catmandu::Fix::Condition::is_true 1.0606
-      Catmandu::Fix::Condition::less_than 1.0606
-      Catmandu::Fix::Condition::valid 1.0606
-      Catmandu::Fix::Has 1.0606
-      Catmandu::Fix::Inlineable 1.0606
-      Catmandu::Fix::Parser 1.0606
-      Catmandu::Fix::SimpleGetValue 1.0606
-      Catmandu::Fix::add 1.0606
-      Catmandu::Fix::add_field 1.0606
-      Catmandu::Fix::add_to_exporter 1.0606
-      Catmandu::Fix::add_to_store 1.0606
-      Catmandu::Fix::append 1.0606
-      Catmandu::Fix::array 1.0606
-      Catmandu::Fix::assoc 1.0606
-      Catmandu::Fix::capitalize 1.0606
-      Catmandu::Fix::clone 1.0606
-      Catmandu::Fix::code 1.0606
-      Catmandu::Fix::collapse 1.0606
+      Catmandu::Fix::Base 1.08
+      Catmandu::Fix::Bind 1.08
+      Catmandu::Fix::Bind::Group 1.08
+      Catmandu::Fix::Bind::benchmark 1.08
+      Catmandu::Fix::Bind::each 1.08
+      Catmandu::Fix::Bind::hashmap 1.08
+      Catmandu::Fix::Bind::identity 1.08
+      Catmandu::Fix::Bind::importer 1.08
+      Catmandu::Fix::Bind::iterate 1.08
+      Catmandu::Fix::Bind::list 1.08
+      Catmandu::Fix::Bind::maybe 1.08
+      Catmandu::Fix::Bind::timeout 1.08
+      Catmandu::Fix::Bind::visitor 1.08
+      Catmandu::Fix::Bind::with 1.08
+      Catmandu::Fix::Condition 1.08
+      Catmandu::Fix::Condition::SimpleAllTest 1.08
+      Catmandu::Fix::Condition::SimpleAnyTest 1.08
+      Catmandu::Fix::Condition::SimpleCompareTest 1.08
+      Catmandu::Fix::Condition::all_equal 1.08
+      Catmandu::Fix::Condition::all_match 1.08
+      Catmandu::Fix::Condition::any_equal 1.08
+      Catmandu::Fix::Condition::any_match 1.08
+      Catmandu::Fix::Condition::exists 1.08
+      Catmandu::Fix::Condition::greater_than 1.08
+      Catmandu::Fix::Condition::in 1.08
+      Catmandu::Fix::Condition::is_array 1.08
+      Catmandu::Fix::Condition::is_false 1.08
+      Catmandu::Fix::Condition::is_null 1.08
+      Catmandu::Fix::Condition::is_number 1.08
+      Catmandu::Fix::Condition::is_object 1.08
+      Catmandu::Fix::Condition::is_string 1.08
+      Catmandu::Fix::Condition::is_true 1.08
+      Catmandu::Fix::Condition::less_than 1.08
+      Catmandu::Fix::Condition::valid 1.08
+      Catmandu::Fix::Has 1.08
+      Catmandu::Fix::Inlineable 1.08
+      Catmandu::Fix::Parser 1.08
+      Catmandu::Fix::SimpleGetValue 1.08
+      Catmandu::Fix::add 1.08
+      Catmandu::Fix::add_field 1.08
+      Catmandu::Fix::add_to_exporter 1.08
+      Catmandu::Fix::add_to_store 1.08
+      Catmandu::Fix::append 1.08
+      Catmandu::Fix::array 1.08
+      Catmandu::Fix::assoc 1.08
+      Catmandu::Fix::capitalize 1.08
+      Catmandu::Fix::clone 1.08
+      Catmandu::Fix::code 1.08
+      Catmandu::Fix::collapse 1.08
       Catmandu::Fix::compact undef
-      Catmandu::Fix::copy 1.0606
-      Catmandu::Fix::copy_field 1.0606
-      Catmandu::Fix::count 1.0606
-      Catmandu::Fix::downcase 1.0606
-      Catmandu::Fix::error 1.0606
-      Catmandu::Fix::expand 1.0606
-      Catmandu::Fix::expand_date 1.0606
-      Catmandu::Fix::export_to_string 1.0606
-      Catmandu::Fix::filter 1.0606
-      Catmandu::Fix::flatten 1.0606
-      Catmandu::Fix::format 1.0606
-      Catmandu::Fix::from_json 1.0606
-      Catmandu::Fix::hash 1.0606
-      Catmandu::Fix::import 1.0606
-      Catmandu::Fix::import_from_string 1.0606
-      Catmandu::Fix::include 1.0606
-      Catmandu::Fix::index 1.0606
-      Catmandu::Fix::int 1.0606
-      Catmandu::Fix::join 1.0606
-      Catmandu::Fix::join_field 1.0606
-      Catmandu::Fix::log 1.0606
-      Catmandu::Fix::lookup 1.0606
-      Catmandu::Fix::lookup_in_store 1.0606
-      Catmandu::Fix::move 1.0606
-      Catmandu::Fix::move_field 1.0606
-      Catmandu::Fix::nothing 1.0606
-      Catmandu::Fix::parse_text 1.0606
-      Catmandu::Fix::paste 1.0606
-      Catmandu::Fix::perlcode 1.0606
-      Catmandu::Fix::prepend 1.0606
-      Catmandu::Fix::random 1.0606
-      Catmandu::Fix::reject 1.0606
-      Catmandu::Fix::remove 1.0606
-      Catmandu::Fix::remove_field 1.0606
-      Catmandu::Fix::rename 1.0606
-      Catmandu::Fix::replace_all 1.0606
-      Catmandu::Fix::retain 1.0606
-      Catmandu::Fix::retain_field 1.0606
-      Catmandu::Fix::reverse 1.0606
+      Catmandu::Fix::copy 1.08
+      Catmandu::Fix::copy_field 1.08
+      Catmandu::Fix::count 1.08
+      Catmandu::Fix::downcase 1.08
+      Catmandu::Fix::error 1.08
+      Catmandu::Fix::expand 1.08
+      Catmandu::Fix::expand_date 1.08
+      Catmandu::Fix::export_to_string 1.08
+      Catmandu::Fix::filter 1.08
+      Catmandu::Fix::flatten 1.08
+      Catmandu::Fix::format 1.08
+      Catmandu::Fix::from_json 1.08
+      Catmandu::Fix::hash 1.08
+      Catmandu::Fix::import 1.08
+      Catmandu::Fix::import_from_string 1.08
+      Catmandu::Fix::include 1.08
+      Catmandu::Fix::index 1.08
+      Catmandu::Fix::int 1.08
+      Catmandu::Fix::join 1.08
+      Catmandu::Fix::join_field 1.08
+      Catmandu::Fix::log 1.08
+      Catmandu::Fix::lookup 1.08
+      Catmandu::Fix::lookup_in_store 1.08
+      Catmandu::Fix::move 1.08
+      Catmandu::Fix::move_field 1.08
+      Catmandu::Fix::nothing 1.08
+      Catmandu::Fix::parse_text 1.08
+      Catmandu::Fix::paste 1.08
+      Catmandu::Fix::perlcode 1.08
+      Catmandu::Fix::prepend 1.08
+      Catmandu::Fix::random 1.08
+      Catmandu::Fix::reject 1.08
+      Catmandu::Fix::remove 1.08
+      Catmandu::Fix::remove_field 1.08
+      Catmandu::Fix::rename 1.08
+      Catmandu::Fix::replace_all 1.08
+      Catmandu::Fix::retain 1.08
+      Catmandu::Fix::retain_field 1.08
+      Catmandu::Fix::reverse 1.08
       Catmandu::Fix::search_in_store undef
-      Catmandu::Fix::set 1.0606
-      Catmandu::Fix::set_array 1.0606
-      Catmandu::Fix::set_field 1.0606
-      Catmandu::Fix::set_hash 1.0606
-      Catmandu::Fix::sleep 1.0606
-      Catmandu::Fix::sort 1.0606
-      Catmandu::Fix::sort_field 1.0606
-      Catmandu::Fix::split 1.0606
-      Catmandu::Fix::split_field 1.0606
-      Catmandu::Fix::string 1.0606
-      Catmandu::Fix::substring 1.0606
-      Catmandu::Fix::sum 1.0606
-      Catmandu::Fix::to_json 1.0606
-      Catmandu::Fix::trim 1.0606
-      Catmandu::Fix::uniq 1.0606
-      Catmandu::Fix::upcase 1.0606
-      Catmandu::Fix::uri_decode 1.0606
-      Catmandu::Fix::uri_encode 1.0606
-      Catmandu::Fix::vacuum 1.0606
-      Catmandu::FixError 1.0606
-      Catmandu::FixParseError 1.0606
-      Catmandu::Fixable 1.0606
-      Catmandu::HTTPError 1.0606
-      Catmandu::Hits 1.0606
-      Catmandu::IdGenerator 1.0606
-      Catmandu::IdGenerator::Mock 1.0606
-      Catmandu::IdGenerator::UUID 1.0606
-      Catmandu::Importer 1.0606
-      Catmandu::Importer::CSV 1.0606
-      Catmandu::Importer::JSON 1.0606
-      Catmandu::Importer::Mock 1.0606
-      Catmandu::Importer::Modules 1.0606
-      Catmandu::Importer::Multi 1.0606
-      Catmandu::Importer::Null 1.0606
-      Catmandu::Importer::TSV 1.0606
-      Catmandu::Importer::Text 1.0606
-      Catmandu::Importer::YAML 1.0606
-      Catmandu::Interactive 1.0606
-      Catmandu::Iterable 1.0606
-      Catmandu::Iterator 1.0606
-      Catmandu::Logger 1.0606
-      Catmandu::MultiIterator 1.0606
-      Catmandu::NoSuchFixPackage 1.0606
-      Catmandu::NoSuchPackage 1.0606
-      Catmandu::NotImplemented 1.0606
-      Catmandu::Paged 1.0606
-      Catmandu::Pluggable 1.0606
-      Catmandu::Plugin::Datestamps 1.0606
-      Catmandu::Plugin::SideCar 1.0606
-      Catmandu::Plugin::Versioning 1.0606
-      Catmandu::Sane 1.0606
-      Catmandu::Searchable 1.0606
-      Catmandu::Serializer 1.0606
-      Catmandu::Serializer::json 1.0606
-      Catmandu::Store 1.0606
-      Catmandu::Store::File::Memory 1.0606
-      Catmandu::Store::File::Memory::Bag 1.0606
-      Catmandu::Store::File::Memory::Index 1.0606
-      Catmandu::Store::File::Multi 1.0606
-      Catmandu::Store::File::Multi::Bag 1.0606
-      Catmandu::Store::File::Multi::Index 1.0606
-      Catmandu::Store::File::Simple 1.0606
-      Catmandu::Store::File::Simple::Bag 1.0606
-      Catmandu::Store::File::Simple::Index 1.0606
-      Catmandu::Store::Hash 1.0606
-      Catmandu::Store::Hash::Bag 1.0606
-      Catmandu::Store::Multi 1.0606
-      Catmandu::Store::Multi::Bag 1.0606
-      Catmandu::TabularExporter 1.0606
-      Catmandu::Transactional 1.0606
-      Catmandu::Util 1.0606
-      Catmandu::Validator 1.0606
-      Catmandu::Validator::Simple 1.0606
+      Catmandu::Fix::set 1.08
+      Catmandu::Fix::set_array 1.08
+      Catmandu::Fix::set_field 1.08
+      Catmandu::Fix::set_hash 1.08
+      Catmandu::Fix::sleep 1.08
+      Catmandu::Fix::sort 1.08
+      Catmandu::Fix::sort_field 1.08
+      Catmandu::Fix::split 1.08
+      Catmandu::Fix::split_field 1.08
+      Catmandu::Fix::string 1.08
+      Catmandu::Fix::substring 1.08
+      Catmandu::Fix::sum 1.08
+      Catmandu::Fix::to_json 1.08
+      Catmandu::Fix::trim 1.08
+      Catmandu::Fix::uniq 1.08
+      Catmandu::Fix::upcase 1.08
+      Catmandu::Fix::uri_decode 1.08
+      Catmandu::Fix::uri_encode 1.08
+      Catmandu::Fix::vacuum 1.08
+      Catmandu::FixError 1.08
+      Catmandu::FixParseError 1.08
+      Catmandu::Fixable 1.08
+      Catmandu::HTTPError 1.08
+      Catmandu::Hits 1.08
+      Catmandu::IdGenerator 1.08
+      Catmandu::IdGenerator::Mock 1.08
+      Catmandu::IdGenerator::UUID 1.08
+      Catmandu::Importer 1.08
+      Catmandu::Importer::CSV 1.08
+      Catmandu::Importer::DKVP 1.08
+      Catmandu::Importer::JSON 1.08
+      Catmandu::Importer::Mock 1.08
+      Catmandu::Importer::Modules 1.08
+      Catmandu::Importer::Multi 1.08
+      Catmandu::Importer::Null 1.08
+      Catmandu::Importer::TSV 1.08
+      Catmandu::Importer::Text 1.08
+      Catmandu::Importer::YAML 1.08
+      Catmandu::Interactive 1.08
+      Catmandu::Iterable 1.08
+      Catmandu::Iterator 1.08
+      Catmandu::Logger 1.08
+      Catmandu::MultiIterator 1.08
+      Catmandu::NoSuchFixPackage 1.08
+      Catmandu::NoSuchPackage 1.08
+      Catmandu::NotImplemented 1.08
+      Catmandu::Paged 1.08
+      Catmandu::Pluggable 1.08
+      Catmandu::Plugin::Datestamps 1.08
+      Catmandu::Plugin::Readonly 1.08
+      Catmandu::Plugin::SideCar 1.08
+      Catmandu::Plugin::Versioning 1.08
+      Catmandu::Sane 1.08
+      Catmandu::Searchable 1.08
+      Catmandu::Serializer 1.08
+      Catmandu::Serializer::json 1.08
+      Catmandu::Store 1.08
+      Catmandu::Store::File::Memory 1.08
+      Catmandu::Store::File::Memory::Bag 1.08
+      Catmandu::Store::File::Memory::Index 1.08
+      Catmandu::Store::File::Multi 1.08
+      Catmandu::Store::File::Multi::Bag 1.08
+      Catmandu::Store::File::Multi::Index 1.08
+      Catmandu::Store::File::Simple 1.08
+      Catmandu::Store::File::Simple::Bag 1.08
+      Catmandu::Store::File::Simple::Index 1.08
+      Catmandu::Store::Hash 1.08
+      Catmandu::Store::Hash::Bag 1.08
+      Catmandu::Store::Multi 1.08
+      Catmandu::Store::Multi::Bag 1.08
+      Catmandu::TabularExporter 1.08
+      Catmandu::Transactional 1.08
+      Catmandu::Util 1.08
+      Catmandu::Validator 1.08
+      Catmandu::Validator::Simple 1.08
     requirements:
       Any::URI::Escape 0
       App::Cmd 0.33
@@ -354,6 +358,7 @@ DISTRIBUTIONS
       Parser::MGC 0.15
       Path::Iterator::Rule 0
       Path::Tiny 0
+      String::CamelCase 0
       Sub::Exporter 0.982
       Sub::Quote 0
       Text::CSV 1.21
@@ -440,15 +445,16 @@ DISTRIBUTIONS
       base 0
       strict 0
       warnings 0
-  Cpanel-JSON-XS-3.0239
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-3.0239.tar.gz
+  Cpanel-JSON-XS-4.01
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.01.tar.gz
     provides:
-      Cpanel::JSON::XS 3.0239
+      Cpanel::JSON::XS 4.01
+      Cpanel::JSON::XS::Type undef
     requirements:
       ExtUtils::MakeMaker 0
       Pod::Text 2.08
-  DBI-1.637
-    pathname: T/TI/TIMB/DBI-1.637.tar.gz
+  DBI-1.640
+    pathname: T/TI/TIMB/DBI-1.640.tar.gz
     provides:
       Bundle::DBI 12.008696
       DBD::DBM 0.08
@@ -483,6 +489,13 @@ DISTRIBUTIONS
       DBD::Gofer::db 0.015327
       DBD::Gofer::dr 0.015327
       DBD::Gofer::st 0.015327
+      DBD::Mem 0.001
+      DBD::Mem::DataSource 0.001
+      DBD::Mem::Statement 0.001
+      DBD::Mem::Table 0.001
+      DBD::Mem::db 0.001
+      DBD::Mem::dr 0.001
+      DBD::Mem::st 0.001
       DBD::NullP 12.014715
       DBD::NullP::db 12.014715
       DBD::NullP::dr 12.014715
@@ -497,7 +510,7 @@ DISTRIBUTIONS
       DBD::Sponge::dr 12.010003
       DBD::Sponge::st 12.010003
       DBDI 12.015129
-      DBI 1.637
+      DBI 1.640
       DBI::Const::GetInfo::ANSI 2.008697
       DBI::Const::GetInfo::ODBC 2.011374
       DBI::Const::GetInfoReturn 2.008697
@@ -537,9 +550,10 @@ DISTRIBUTIONS
       DBI::SQL::Nano::Table_ 1.015544
       DBI::Util::CacheMemory 0.010315
       DBI::Util::_accessor 0.009479
-      DBI::common 1.637
+      DBI::common 1.640
     requirements:
       ExtUtils::MakeMaker 6.48
+      Storable 2.16
       Test::Simple 0.90
       perl 5.008
   Data-Compare-1.25
@@ -582,7 +596,7 @@ DISTRIBUTIONS
       ExtUtils::ParseXS 3.18
       Hash::Util::FieldHash::Compat 0
       Module::Build 0.4005
-      Module::Build::XSUtil 0.16
+      Module::Build::XSUtil 0.18
       Scope::Guard 0
       Test::Exception 0.27
       Test::More 0.62
@@ -609,11 +623,11 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Sub::Exporter::Progressive 0.001011
       perl 5.006
-  Devel-StackTrace-2.02
-    pathname: D/DR/DROLSKY/Devel-StackTrace-2.02.tar.gz
+  Devel-StackTrace-2.03
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.03.tar.gz
     provides:
-      Devel::StackTrace 2.02
-      Devel::StackTrace::Frame 2.02
+      Devel::StackTrace 2.03
+      Devel::StackTrace::Frame 2.03
     requirements:
       ExtUtils::MakeMaker 0
       File::Spec 0
@@ -654,11 +668,11 @@ DISTRIBUTIONS
       Encode::Alias 0
       ExtUtils::MakeMaker 0
       perl 5.008
-  Exception-Class-1.43
-    pathname: D/DR/DROLSKY/Exception-Class-1.43.tar.gz
+  Exception-Class-1.44
+    pathname: D/DR/DROLSKY/Exception-Class-1.44.tar.gz
     provides:
-      Exception::Class 1.43
-      Exception::Class::Base 1.43
+      Exception::Class 1.44
+      Exception::Class::Base 1.44
     requirements:
       Class::Data::Inheritable 0.02
       Devel::StackTrace 2.00
@@ -764,12 +778,12 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  Getopt-Long-Descriptive-0.100
-    pathname: R/RJ/RJBS/Getopt-Long-Descriptive-0.100.tar.gz
+  Getopt-Long-Descriptive-0.101
+    pathname: R/RJ/RJBS/Getopt-Long-Descriptive-0.101.tar.gz
     provides:
-      Getopt::Long::Descriptive 0.100
-      Getopt::Long::Descriptive::Opts 0.100
-      Getopt::Long::Descriptive::Usage 0.100
+      Getopt::Long::Descriptive 0.101
+      Getopt::Long::Descriptive::Opts 0.101
+      Getopt::Long::Descriptive::Usage 0.101
     requirements:
       Carp 0
       ExtUtils::MakeMaker 0
@@ -844,19 +858,19 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Time::Local 0
       perl 5.006002
-  HTTP-Message-6.13
-    pathname: O/OA/OALDERS/HTTP-Message-6.13.tar.gz
+  HTTP-Message-6.14
+    pathname: O/OA/OALDERS/HTTP-Message-6.14.tar.gz
     provides:
-      HTTP::Config 6.13
-      HTTP::Headers 6.13
-      HTTP::Headers::Auth 6.13
-      HTTP::Headers::ETag 6.13
-      HTTP::Headers::Util 6.13
-      HTTP::Message 6.13
-      HTTP::Request 6.13
-      HTTP::Request::Common 6.13
-      HTTP::Response 6.13
-      HTTP::Status 6.13
+      HTTP::Config 6.14
+      HTTP::Headers 6.14
+      HTTP::Headers::Auth 6.14
+      HTTP::Headers::ETag 6.14
+      HTTP::Headers::Util 6.14
+      HTTP::Message 6.14
+      HTTP::Request 6.14
+      HTTP::Request::Common 6.14
+      HTTP::Response 6.14
+      HTTP::Status 6.14
     requirements:
       Carp 0
       Compress::Raw::Zlib 0
@@ -975,19 +989,19 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  List-MoreUtils-0.426
-    pathname: R/RE/REHSACK/List-MoreUtils-0.426.tar.gz
+  List-MoreUtils-0.428
+    pathname: R/RE/REHSACK/List-MoreUtils-0.428.tar.gz
     provides:
-      List::MoreUtils 0.426
-      List::MoreUtils::PP 0.426
+      List::MoreUtils 0.428
+      List::MoreUtils::PP 0.428
     requirements:
       Exporter::Tiny 0.038
       ExtUtils::MakeMaker 0
       List::MoreUtils::XS 0.426
-  List-MoreUtils-XS-0.426
-    pathname: R/RE/REHSACK/List-MoreUtils-XS-0.426.tar.gz
+  List-MoreUtils-XS-0.428
+    pathname: R/RE/REHSACK/List-MoreUtils-XS-0.428.tar.gz
     provides:
-      List::MoreUtils::XS 0.426
+      List::MoreUtils::XS 0.428
     requirements:
       Carp 0
       ExtUtils::MakeMaker 0
@@ -998,24 +1012,24 @@ DISTRIBUTIONS
       IPC::Cmd 0
       XSLoader 0.22
       base 0
-  Log-Any-1.701
-    pathname: P/PR/PREACTION/Log-Any-1.701.tar.gz
+  Log-Any-1.705
+    pathname: P/PR/PREACTION/Log-Any-1.705.tar.gz
     provides:
-      Log::Any 1.701
-      Log::Any::Adapter 1.701
-      Log::Any::Adapter::Base 1.701
-      Log::Any::Adapter::File 1.701
-      Log::Any::Adapter::Null 1.701
-      Log::Any::Adapter::Stderr 1.701
-      Log::Any::Adapter::Stdout 1.701
-      Log::Any::Adapter::Syslog 1.701
-      Log::Any::Adapter::Test 1.701
-      Log::Any::Adapter::Util 1.701
-      Log::Any::Manager 1.701
-      Log::Any::Proxy 1.701
-      Log::Any::Proxy::Null 1.701
-      Log::Any::Proxy::Test 1.701
-      Log::Any::Test 1.701
+      Log::Any 1.705
+      Log::Any::Adapter 1.705
+      Log::Any::Adapter::Base 1.705
+      Log::Any::Adapter::File 1.705
+      Log::Any::Adapter::Null 1.705
+      Log::Any::Adapter::Stderr 1.705
+      Log::Any::Adapter::Stdout 1.705
+      Log::Any::Adapter::Syslog 1.705
+      Log::Any::Adapter::Test 1.705
+      Log::Any::Adapter::Util 1.705
+      Log::Any::Manager 1.705
+      Log::Any::Proxy 1.705
+      Log::Any::Proxy::Null 1.705
+      Log::Any::Proxy::Test 1.705
+      Log::Any::Test 1.705
     requirements:
       B 0
       Carp 0
@@ -1032,12 +1046,12 @@ DISTRIBUTIONS
       constant 0
       strict 0
       warnings 0
-  MIME-Types-2.13
-    pathname: M/MA/MARKOV/MIME-Types-2.13.tar.gz
+  MIME-Types-2.17
+    pathname: M/MA/MARKOV/MIME-Types-2.17.tar.gz
     provides:
-      MIME::Type 2.13
-      MIME::Types 2.13
-      MojoX::MIME::Types 2.13
+      MIME::Type 2.17
+      MIME::Types 2.17
+      MojoX::MIME::Types 2.17
     requirements:
       ExtUtils::MakeMaker 0
       File::Basename 0
@@ -1119,10 +1133,10 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Module-Build-XSUtil-0.16
-    pathname: H/HI/HIDEAKIO/Module-Build-XSUtil-0.16.tar.gz
+  Module-Build-XSUtil-0.18
+    pathname: H/HI/HIDEAKIO/Module-Build-XSUtil-0.18.tar.gz
     provides:
-      Module::Build::XSUtil 0.16
+      Module::Build::XSUtil 0.18
     requirements:
       Devel::CheckCompiler 0
       Devel::PPPort 0
@@ -1187,20 +1201,20 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Moo-2.003002
-    pathname: H/HA/HAARG/Moo-2.003002.tar.gz
+  Moo-2.003004
+    pathname: H/HA/HAARG/Moo-2.003004.tar.gz
     provides:
       Method::Generate::Accessor undef
       Method::Generate::BuildAll undef
       Method::Generate::Constructor undef
       Method::Generate::DemolishAll undef
-      Moo 2.003002
+      Moo 2.003004
       Moo::HandleMoose undef
       Moo::HandleMoose::FakeConstructor undef
       Moo::HandleMoose::FakeMetaClass undef
       Moo::HandleMoose::_TypeMap undef
       Moo::Object undef
-      Moo::Role 2.003002
+      Moo::Role 2.003004
       Moo::_Utils undef
       Moo::_mro undef
       Moo::_strictures undef
@@ -1366,11 +1380,11 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  Role-Tiny-2.000005
-    pathname: H/HA/HAARG/Role-Tiny-2.000005.tar.gz
+  Role-Tiny-2.000006
+    pathname: H/HA/HAARG/Role-Tiny-2.000006.tar.gz
     provides:
-      Role::Tiny 2.000005
-      Role::Tiny::With 2.000005
+      Role::Tiny 2.000006
+      Role::Tiny::With 2.000006
     requirements:
       Exporter 5.57
       perl 5.006
@@ -1382,6 +1396,13 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.006001
+  String-CamelCase-0.03
+    pathname: H/HI/HIO/String-CamelCase-0.03.tar.gz
+    provides:
+      String::CamelCase undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
   String-RewritePrefix-0.007
     pathname: R/RJ/RJBS/String-RewritePrefix-0.007.tar.gz
     provides:
@@ -1422,11 +1443,11 @@ DISTRIBUTIONS
       Scalar::Util 0
       strict 0
       warnings 0
-  Sub-Quote-2.004000
-    pathname: H/HA/HAARG/Sub-Quote-2.004000.tar.gz
+  Sub-Quote-2.005000
+    pathname: H/HA/HAARG/Sub-Quote-2.005000.tar.gz
     provides:
-      Sub::Defer 2.004000
-      Sub::Quote 2.004000
+      Sub::Defer 2.005000
+      Sub::Quote 2.005000
     requirements:
       ExtUtils::MakeMaker 0
       Scalar::Util 0
@@ -1442,16 +1463,17 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
-  Task-Weaken-1.04
-    pathname: A/AD/ADAMK/Task-Weaken-1.04.tar.gz
+  Task-Weaken-1.05
+    pathname: E/ET/ETHER/Task-Weaken-1.05.tar.gz
     provides:
-      Task::Weaken 1.04
+      Task::Weaken 1.05
     requirements:
-      ExtUtils::MakeMaker 6.42
-      File::Spec 0.80
+      Config 0
+      ExtUtils::MakeMaker 0
+      File::Spec 0
       Scalar::Util 1.14
-      Test::More 0.42
-      perl 5.005
+      perl 5.006
+      strict 0
   Test-Deep-1.127
     pathname: R/RJ/RJBS/Test-Deep-1.127.tar.gz
     provides:
@@ -1550,72 +1572,73 @@ DISTRIBUTIONS
       Test::Harness 3.35
       Test::More 1.302047
       Test::Warn 0.30
-  Test-Simple-1.302106
-    pathname: E/EX/EXODIST/Test-Simple-1.302106.tar.gz
+  Test-Simple-1.302122
+    pathname: E/EX/EXODIST/Test-Simple-1.302122.tar.gz
     provides:
-      Test2 1.302106
-      Test2::API 1.302106
-      Test2::API::Breakage 1.302106
-      Test2::API::Context 1.302106
-      Test2::API::Instance 1.302106
-      Test2::API::Stack 1.302106
-      Test2::Event 1.302106
-      Test2::Event::Bail 1.302106
-      Test2::Event::Diag 1.302106
-      Test2::Event::Encoding 1.302106
-      Test2::Event::Exception 1.302106
-      Test2::Event::Fail 1.302106
-      Test2::Event::Generic 1.302106
-      Test2::Event::Note 1.302106
-      Test2::Event::Ok 1.302106
-      Test2::Event::Pass 1.302106
-      Test2::Event::Plan 1.302106
-      Test2::Event::Skip 1.302106
-      Test2::Event::Subtest 1.302106
-      Test2::Event::TAP::Version 1.302106
-      Test2::Event::Waiting 1.302106
-      Test2::EventFacet 1.302106
-      Test2::EventFacet::About 1.302106
-      Test2::EventFacet::Amnesty 1.302106
-      Test2::EventFacet::Assert 1.302106
-      Test2::EventFacet::Control 1.302106
-      Test2::EventFacet::Error 1.302106
-      Test2::EventFacet::Info 1.302106
-      Test2::EventFacet::Meta 1.302106
-      Test2::EventFacet::Parent 1.302106
-      Test2::EventFacet::Plan 1.302106
-      Test2::EventFacet::Trace 1.302106
-      Test2::Formatter 1.302106
-      Test2::Formatter::TAP 1.302106
-      Test2::Hub 1.302106
-      Test2::Hub::Interceptor 1.302106
-      Test2::Hub::Interceptor::Terminator 1.302106
-      Test2::Hub::Subtest 1.302106
-      Test2::IPC 1.302106
-      Test2::IPC::Driver 1.302106
-      Test2::IPC::Driver::Files 1.302106
-      Test2::Tools::Tiny 1.302106
-      Test2::Util 1.302106
-      Test2::Util::ExternalMeta 1.302106
-      Test2::Util::Facets2Legacy 1.302106
-      Test2::Util::HashBase 1.302106
-      Test2::Util::Trace 1.302106
-      Test::Builder 1.302106
-      Test::Builder::Formatter 1.302106
+      Test2 1.302122
+      Test2::API 1.302122
+      Test2::API::Breakage 1.302122
+      Test2::API::Context 1.302122
+      Test2::API::Instance 1.302122
+      Test2::API::Stack 1.302122
+      Test2::Event 1.302122
+      Test2::Event::Bail 1.302122
+      Test2::Event::Diag 1.302122
+      Test2::Event::Encoding 1.302122
+      Test2::Event::Exception 1.302122
+      Test2::Event::Fail 1.302122
+      Test2::Event::Generic 1.302122
+      Test2::Event::Note 1.302122
+      Test2::Event::Ok 1.302122
+      Test2::Event::Pass 1.302122
+      Test2::Event::Plan 1.302122
+      Test2::Event::Skip 1.302122
+      Test2::Event::Subtest 1.302122
+      Test2::Event::TAP::Version 1.302122
+      Test2::Event::Waiting 1.302122
+      Test2::EventFacet 1.302122
+      Test2::EventFacet::About 1.302122
+      Test2::EventFacet::Amnesty 1.302122
+      Test2::EventFacet::Assert 1.302122
+      Test2::EventFacet::Control 1.302122
+      Test2::EventFacet::Error 1.302122
+      Test2::EventFacet::Info 1.302122
+      Test2::EventFacet::Meta 1.302122
+      Test2::EventFacet::Parent 1.302122
+      Test2::EventFacet::Plan 1.302122
+      Test2::EventFacet::Render 1.302122
+      Test2::EventFacet::Trace 1.302122
+      Test2::Formatter 1.302122
+      Test2::Formatter::TAP 1.302122
+      Test2::Hub 1.302122
+      Test2::Hub::Interceptor 1.302122
+      Test2::Hub::Interceptor::Terminator 1.302122
+      Test2::Hub::Subtest 1.302122
+      Test2::IPC 1.302122
+      Test2::IPC::Driver 1.302122
+      Test2::IPC::Driver::Files 1.302122
+      Test2::Tools::Tiny 1.302122
+      Test2::Util 1.302122
+      Test2::Util::ExternalMeta 1.302122
+      Test2::Util::Facets2Legacy 1.302122
+      Test2::Util::HashBase 1.302122
+      Test2::Util::Trace 1.302122
+      Test::Builder 1.302122
+      Test::Builder::Formatter 1.302122
       Test::Builder::IO::Scalar 2.114
-      Test::Builder::Module 1.302106
-      Test::Builder::Tester 1.302106
-      Test::Builder::Tester::Color 1.302106
-      Test::Builder::Tester::Tie 1.302106
-      Test::Builder::TodoDiag 1.302106
-      Test::More 1.302106
-      Test::Simple 1.302106
-      Test::Tester 1.302106
-      Test::Tester::Capture 1.302106
-      Test::Tester::CaptureRunner 1.302106
-      Test::Tester::Delegate 1.302106
-      Test::use::ok 1.302106
-      ok 1.302106
+      Test::Builder::Module 1.302122
+      Test::Builder::Tester 1.302122
+      Test::Builder::Tester::Color 1.302122
+      Test::Builder::Tester::Tie 1.302122
+      Test::Builder::TodoDiag 1.302122
+      Test::More 1.302122
+      Test::Simple 1.302122
+      Test::Tester 1.302122
+      Test::Tester::Capture 1.302122
+      Test::Tester::CaptureRunner 1.302122
+      Test::Tester::Delegate 1.302122
+      Test::use::ok 1.302122
+      ok 1.302122
     requirements:
       ExtUtils::MakeMaker 0
       File::Spec 0
@@ -1703,10 +1726,10 @@ DISTRIBUTIONS
       Scalar::Util 0
       Sub::Quote 0
       overload 0
-  Try-Tiny-0.28
-    pathname: E/ET/ETHER/Try-Tiny-0.28.tar.gz
+  Try-Tiny-0.30
+    pathname: E/ET/ETHER/Try-Tiny-0.30.tar.gz
     provides:
-      Try::Tiny 0.28
+      Try::Tiny 0.30
     requirements:
       Carp 0
       Exporter 5.57
@@ -1730,52 +1753,52 @@ DISTRIBUTIONS
       perl 5.006000
       strict 0
       warnings 0
-  URI-1.72
-    pathname: E/ET/ETHER/URI-1.72.tar.gz
+  URI-1.73
+    pathname: E/ET/ETHER/URI-1.73.tar.gz
     provides:
-      URI 1.72
+      URI 1.73
       URI::Escape 3.31
       URI::Heuristic 4.20
-      URI::IRI 1.72
-      URI::QueryParam 1.72
-      URI::Split 1.72
+      URI::IRI 1.73
+      URI::QueryParam 1.73
+      URI::Split 1.73
       URI::URL 5.04
       URI::WithBase 2.20
-      URI::data 1.72
+      URI::data 1.73
       URI::file 4.21
-      URI::file::Base 1.72
-      URI::file::FAT 1.72
-      URI::file::Mac 1.72
-      URI::file::OS2 1.72
-      URI::file::QNX 1.72
-      URI::file::Unix 1.72
-      URI::file::Win32 1.72
-      URI::ftp 1.72
-      URI::gopher 1.72
-      URI::http 1.72
-      URI::https 1.72
-      URI::ldap 1.72
-      URI::ldapi 1.72
-      URI::ldaps 1.72
-      URI::mailto 1.72
-      URI::mms 1.72
-      URI::news 1.72
-      URI::nntp 1.72
-      URI::pop 1.72
-      URI::rlogin 1.72
-      URI::rsync 1.72
-      URI::rtsp 1.72
-      URI::rtspu 1.72
-      URI::sftp 1.72
-      URI::sip 1.72
-      URI::sips 1.72
-      URI::snews 1.72
-      URI::ssh 1.72
-      URI::telnet 1.72
-      URI::tn3270 1.72
-      URI::urn 1.72
-      URI::urn::isbn 1.72
-      URI::urn::oid 1.72
+      URI::file::Base 1.73
+      URI::file::FAT 1.73
+      URI::file::Mac 1.73
+      URI::file::OS2 1.73
+      URI::file::QNX 1.73
+      URI::file::Unix 1.73
+      URI::file::Win32 1.73
+      URI::ftp 1.73
+      URI::gopher 1.73
+      URI::http 1.73
+      URI::https 1.73
+      URI::ldap 1.73
+      URI::ldapi 1.73
+      URI::ldaps 1.73
+      URI::mailto 1.73
+      URI::mms 1.73
+      URI::news 1.73
+      URI::nntp 1.73
+      URI::pop 1.73
+      URI::rlogin 1.73
+      URI::rsync 1.73
+      URI::rtsp 1.73
+      URI::rtspu 1.73
+      URI::sftp 1.73
+      URI::sip 1.73
+      URI::sips 1.73
+      URI::snews 1.73
+      URI::ssh 1.73
+      URI::telnet 1.73
+      URI::tn3270 1.73
+      URI::urn 1.73
+      URI::urn::isbn 1.73
+      URI::urn::oid 1.73
     requirements:
       Carp 0
       Cwd 0
@@ -1805,10 +1828,10 @@ DISTRIBUTIONS
       URI::Escape 0
       Unicode::Normalize 0
       perl 5.006
-  Variable-Magic-0.61
-    pathname: V/VP/VPIT/Variable-Magic-0.61.tar.gz
+  Variable-Magic-0.62
+    pathname: V/VP/VPIT/Variable-Magic-0.62.tar.gz
     provides:
-      Variable::Magic 0.61
+      Variable::Magic 0.62
     requirements:
       Carp 0
       Config 0
@@ -1843,11 +1866,11 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0.47
-  YAML-LibYAML-0.66
-    pathname: T/TI/TINITA/YAML-LibYAML-0.66.tar.gz
+  YAML-LibYAML-0.69
+    pathname: T/TI/TINITA/YAML-LibYAML-0.69.tar.gz
     provides:
-      YAML::LibYAML 0.66
-      YAML::XS 0.66
+      YAML::LibYAML 0.69
+      YAML::XS 0.69
       YAML::XS::LibYAML undef
     requirements:
       ExtUtils::MakeMaker 0
@@ -1876,10 +1899,10 @@ DISTRIBUTIONS
       perl 5.008001
       strict 0
       warnings 0
-  indirect-0.37
-    pathname: V/VP/VPIT/indirect-0.37.tar.gz
+  indirect-0.38
+    pathname: V/VP/VPIT/indirect-0.38.tar.gz
     provides:
-      indirect 0.37
+      indirect 0.38
     requirements:
       Carp 0
       Config 0
@@ -1894,33 +1917,32 @@ DISTRIBUTIONS
       XSLoader 0
       lib 0
       perl 5.008001
-  libwww-perl-6.27
-    pathname: O/OA/OALDERS/libwww-perl-6.27.tar.gz
+  libwww-perl-6.31
+    pathname: E/ET/ETHER/libwww-perl-6.31.tar.gz
     provides:
-      LWP 6.27
-      LWP::Authen::Basic 6.27
-      LWP::Authen::Digest 6.27
-      LWP::Authen::Ntlm 6.27
-      LWP::ConnCache 6.27
-      LWP::Debug 6.27
-      LWP::Debug::TraceHTTP 6.27
-      LWP::DebugFile 6.27
-      LWP::MemberMixin 6.27
-      LWP::Protocol 6.27
-      LWP::Protocol::MyFTP 6.27
-      LWP::Protocol::cpan 6.27
-      LWP::Protocol::data 6.27
-      LWP::Protocol::file 6.27
-      LWP::Protocol::ftp 6.27
-      LWP::Protocol::gopher 6.27
-      LWP::Protocol::http 6.27
-      LWP::Protocol::loopback 6.27
-      LWP::Protocol::mailto 6.27
-      LWP::Protocol::nntp 6.27
-      LWP::Protocol::nogo 6.27
-      LWP::RobotUA 6.27
-      LWP::Simple 6.27
-      LWP::UserAgent 6.27
+      LWP 6.31
+      LWP::Authen::Basic 6.31
+      LWP::Authen::Digest 6.31
+      LWP::Authen::Ntlm 6.31
+      LWP::ConnCache 6.31
+      LWP::Debug 6.31
+      LWP::Debug::TraceHTTP 6.31
+      LWP::DebugFile 6.31
+      LWP::MemberMixin 6.31
+      LWP::Protocol 6.31
+      LWP::Protocol::cpan 6.31
+      LWP::Protocol::data 6.31
+      LWP::Protocol::file 6.31
+      LWP::Protocol::ftp 6.31
+      LWP::Protocol::gopher 6.31
+      LWP::Protocol::http 6.31
+      LWP::Protocol::loopback 6.31
+      LWP::Protocol::mailto 6.31
+      LWP::Protocol::nntp 6.31
+      LWP::Protocol::nogo 6.31
+      LWP::RobotUA 6.31
+      LWP::Simple 6.31
+      LWP::UserAgent 6.31
       libwww::perl undef
     requirements:
       Digest::MD5 0

--- a/lib/Catmandu/Store/DBI.pm
+++ b/lib/Catmandu/Store/DBI.pm
@@ -21,10 +21,11 @@ has data_source => (
         $_[0]->{data_source} = $ds;
     },
 );
-has username => (is => 'ro', default => sub {''});
-has password => (is => 'ro', default => sub {''});
-has timeout => (is => 'ro', predicate => 1);
+has username                => (is => 'ro', default => sub {''});
+has password                => (is => 'ro', default => sub {''});
+has timeout                 => (is => 'ro', predicate => 1);
 has reconnect_after_timeout => (is => 'ro');
+has default_order           => (is => 'ro', default => sub {'ID'});
 has handler                 => (is => 'lazy');
 has _in_transaction         => (is => 'rw', writer => '_set_in_transaction',);
 has _connect_time           => (is => 'rw', writer => '_set_connect_time');
@@ -247,6 +248,13 @@ See TIMEOUTS below for more information.
 
 Optional. When a timeout is reached, Catmandu reconnects to the database. By
 default set to '0'
+
+=item default_order
+
+Optional. Default the default sorting of results when returning an iterator.
+Choose 'ID' to order on the configured identifier field, 'NONE' to skip all
+ordering, or "$field" where $field is the name of a table column. By default
+set to 'ID'.
 
 =back
 

--- a/lib/Catmandu/Store/DBI/Bag.pm
+++ b/lib/Catmandu/Store/DBI/Bag.pm
@@ -18,7 +18,8 @@ my $default_mapping = {
     _data => {column => 'data', type => 'binary', serialize => 'all',}
 };
 
-has mapping => (is => 'ro', default => sub {+{%$default_mapping}},);
+has mapping       => (is => 'ro', default => sub {+{%$default_mapping}},);
+has default_order => (is => 'ro');    
 
 has _iterator => (
     is      => 'ro',

--- a/lib/Catmandu/Store/DBI/Iterator.pm
+++ b/lib/Catmandu/Store/DBI/Iterator.pm
@@ -9,7 +9,7 @@ our $VERSION = "0.0701";
 
 with 'Catmandu::Iterable';
 
-has bag => (is => 'ro', required => 1);
+has bag   => (is => 'ro', required => 1);
 has where => (is => 'ro');
 has binds => (is => 'lazy');
 has total => (is => 'ro');
@@ -45,9 +45,24 @@ sub _select_sql {
     my $q_id_field = $self->_q_id($id_field);
     my $where      = $self->where;
     my $limit      = $self->limit;
+
     my $sql        = "SELECT * FROM " . $self->_q_id($self->bag->name);
     $sql .= " WHERE $where" if $where;
-    $sql .= " ORDER BY $q_id_field LIMIT $limit OFFSET $start";
+
+    my $default_order = $self->bag->default_order // $self->bag->store->default_order;
+
+    if (defined $default_order) {
+        if ($default_order eq 'ID') {
+            $sql .= " ORDER BY $q_id_field";
+        }
+        elsif ($default_order eq 'NONE') {
+            # no nothing
+        }
+        else {
+            $sql .= " ORDER BY $default_order";
+        }
+    }
+    $sql .= " LIMIT $limit OFFSET $start";
     $sql;
 }
 

--- a/t/06-sqlite.t
+++ b/t/06-sqlite.t
@@ -85,7 +85,8 @@ else {
                                     {column => "title", type => "string"},
                                 author =>
                                     {column => "author", type => "string"}
-                            }
+                            } ,
+                            default_order => 'ID'
                         }
                     }
                 )->bag();


### PR DESCRIPTION
Adding support to choose at Store or Bag level how default ordering of generators should work:

```
store:
    mydb:
         package: DBI
         options:
            data_source: "dbi:mysql:database=mydb"
            username: xyz
            password: xyz
            default_order: NONE
            bags:
                foobar:
                   default_order: ID
```

Options are:

- NONE - don't order
- ID - order on the standard set ID field
- $field - order on a $field column name