### PR TITLE
set total when reaching end to avoid total=1 and so infinite queries

### DIFF
--- a/lib/Catmandu/Store/DBI/Iterator.pm
+++ b/lib/Catmandu/Store/DBI/Iterator.pm
@@ -43,7 +43,7 @@ sub generator {
     sub {
         state $rows;
 
-        return if defined $total && !$total;
+        return if defined $total && $total <= 0;
 
         unless (defined $rows && @$rows) {
             my $dbh = $store->dbh;
@@ -55,6 +55,8 @@ sub generator {
                 or Catmandu::Error->throw($dbh->errstr);
             $sth->execute(@$binds) or Catmandu::Error->throw($sth->errstr);
             $rows = $sth->fetchall_arrayref({});
+            # less results than requested: the end is near
+            $total = scalar(@$rows) if scalar(@$rows) < $limit;
             $sth->finish;
             $start += $limit;
         }


### PR DESCRIPTION
The generator of `Catmandu::Store::DBI::Iterator` keeps executing queries (with offset increased by the limit parameter), even beyond the result boundary. The reason for this is that [this line](https://github.com/LibreCat/Catmandu-DBI/blob/master/lib/Catmandu/Store/DBI/Iterator.pm#L46) is never executed because decrementing of `$total` is [skipped](https://github.com/LibreCat/Catmandu-DBI/blob/master/lib/Catmandu/Store/DBI/Iterator.pm#L62) as soon as `$rows` is empty. So `$total` gets stuck at `1`. I've changed the code to reset `$total` to the number of returned rows from the queries because that means that there won't be any more results.

results 0 - 99
results 100 - 199
results 200 - 201 -> here the generator keeps executing queries