### PR TITLE
auto discover current schema, and create indexes on that schema

### DIFF
--- a/lib/Catmandu/Store/DBI/Handler/Pg.pm
+++ b/lib/Catmandu/Store/DBI/Handler/Pg.pm
@@ -66,10 +66,10 @@ IF NOT EXISTS (
     FROM   pg_class c
     JOIN   pg_namespace n ON n.oid = c.relnamespace
     WHERE  c.relname = '${name}_${col}_idx'
-    AND    n.nspname = 'public'
+    AND    n.nspname = (SELECT CURRENT_SCHEMA)
     ) THEN
 
-    CREATE INDEX ${name}_${col}_idx ON public.${name} (${q_col});
+    CREATE INDEX ${name}_${col}_idx ON ${name} (${q_col});
 END IF;
 
 END\$\$;


### PR DESCRIPTION
In the postgres handler automatic indexes are created in schema public, but that fails if your database has setup a different schema for you, and requires you to do everything within that preconfigured schema.

Done: query for indexes in the current schema, and remove "public" 